### PR TITLE
Db mockup tools

### DIFF
--- a/Dockerfile.glibc-2.12
+++ b/Dockerfile.glibc-2.12
@@ -41,6 +41,8 @@ COPY mockup-tools/pqdb_sql.out /bin/
 COPY mockup-tools/dboutput.sh /root/mockup-tools/
 COPY mockup-tools/root.prof /root/profiles/
 
+RUN mkdir /root/sql
+
 ONBUILD ENV APP_HOME /root/code
 ONBUILD RUN mkdir -p $APP_HOME
 ONBUILD WORKDIR $APP_HOME

--- a/Dockerfile.glibc-2.12
+++ b/Dockerfile.glibc-2.12
@@ -37,6 +37,10 @@ RUN    mkdir -p $HOME/.ssh \
 RUN    echo $'\nservice sshd start\neval `ssh-agent -s`\nssh-add $ORBIT_KEY\n' >> $HOME/.profile \
     && echo $'\nservice sshd start\neval `ssh-agent -s`\nssh-add $ORBIT_KEY\n' >> $HOME/.bash_profile
 
+COPY mockup-tools/pqdb_sql.out /bin/
+COPY mockup-tools/dboutput.sh /root/mockup-tools/
+COPY mockup-tools/root.prof /root/profiles/
+
 ONBUILD ENV APP_HOME /root/code
 ONBUILD RUN mkdir -p $APP_HOME
 ONBUILD WORKDIR $APP_HOME

--- a/Dockerfile.glibc-2.14
+++ b/Dockerfile.glibc-2.14
@@ -34,6 +34,10 @@ RUN    echo PATH=$PATH >> /etc/profile \
     && echo '\n/etc/init.d/ssh start\neval `ssh-agent -s`\nssh-add $ORBIT_KEY\n' >> $HOME/.profile \
     && echo '\n/etc/init.d/ssh start\neval `ssh-agent -s`\nssh-add $ORBIT_KEY\n' >> $HOME/.bash_profile
 
+COPY mockup-tools/pqdb_sql.out /bin/
+COPY mockup-tools/dboutput.sh /root/mockup-tools/
+COPY mockup-tools/root.prof /root/profiles/
+
 ONBUILD ENV APP_HOME /root/code
 ONBUILD RUN mkdir -p $APP_HOME
 ONBUILD WORKDIR $APP_HOME

--- a/Dockerfile.glibc-2.14
+++ b/Dockerfile.glibc-2.14
@@ -38,6 +38,8 @@ COPY mockup-tools/pqdb_sql.out /bin/
 COPY mockup-tools/dboutput.sh /root/mockup-tools/
 COPY mockup-tools/root.prof /root/profiles/
 
+RUN mkdir /root/sql
+
 ONBUILD ENV APP_HOME /root/code
 ONBUILD RUN mkdir -p $APP_HOME
 ONBUILD WORKDIR $APP_HOME

--- a/Dockerfile.musl
+++ b/Dockerfile.musl
@@ -31,6 +31,8 @@ COPY mockup-tools/pqdb_sql.out /bin/
 COPY mockup-tools/dboutput.sh /root/mockup-tools/
 COPY mockup-tools/root.prof /root/profiles/
 
+RUN mkdir /root/sql
+
 ONBUILD ENV APP_HOME /root/code
 ONBUILD RUN mkdir -p $APP_HOME
 ONBUILD WORKDIR $APP_HOME

--- a/Dockerfile.musl
+++ b/Dockerfile.musl
@@ -27,6 +27,10 @@ RUN    echo PATH=$PATH >> /etc/profile \
     && echo $'\n/usr/sbin/sshd\neval `ssh-agent -s`\nssh-add $ORBIT_KEY\n' >> $HOME/.profile \
     && echo $'\n/usr/sbin/sshd\neval `ssh-agent -s`\nssh-add $ORBIT_KEY\n' >> $HOME/.bash_profile
 
+COPY mockup-tools/pqdb_sql.out /bin/
+COPY mockup-tools/dboutput.sh /root/mockup-tools/
+COPY mockup-tools/root.prof /root/profiles/
+
 ONBUILD ENV APP_HOME /root/code
 ONBUILD RUN mkdir -p $APP_HOME
 ONBUILD WORKDIR $APP_HOME

--- a/mockup-tools/dboutput.sh
+++ b/mockup-tools/dboutput.sh
@@ -1,0 +1,7 @@
+cat <<EOF
+D
+-
+X
+
+USERINFO: [server1], [server1]linux:username
+EOF

--- a/mockup-tools/pqdb_sql.out
+++ b/mockup-tools/pqdb_sql.out
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/root/mockup-tools/dboutput.sh

--- a/mockup-tools/root.prof
+++ b/mockup-tools/root.prof
@@ -1,3 +1,3 @@
-#export GOPATH=/home/mrblati/go/
+
 export ORBIT_KEY=/.ssh/orbit_rsa
 

--- a/mockup-tools/root.prof
+++ b/mockup-tools/root.prof
@@ -1,0 +1,3 @@
+#export GOPATH=/home/mrblati/go/
+export ORBIT_KEY=/.ssh/orbit_rsa
+


### PR DESCRIPTION
sollte allen docker-images den db mockup standardmäßig zur verfügung stellen. Konnte es leider nicht testen.

An dieser Stelle: 
hier könnte auch eine aktuelle version von fifa eingebaut werden, eigentlich sogar über wget der aktuellste build des fifa repo...